### PR TITLE
Attachment states

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: node_js
+sudo: required
+node_js:
+  - "node"
+addons:
+  chrome: stable
+cache:
+  directories:
+    - node_modules

--- a/karma.config.js
+++ b/karma.config.js
@@ -2,11 +2,8 @@ module.exports = function(config) {
   config.set({
     frameworks: ['mocha', 'chai'],
     files: [
-      {
-        pattern: '../dist/index.js',
-        type: 'module'
-      },
-      'test.js'
+      {pattern: 'dist/index.js', type: 'module'},
+      {pattern: 'test/test.js', type: 'module'}
     ],
     reporters: ['mocha'],
     port: 9876,

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "compile": "tsc",
     "build": "rollup -c",
     "pretest": "npm run build",
-    "test": "karma start test/karma.config.js",
+    "test": "karma start karma.config.js",
     "prepublishOnly": "npm run build",
     "postpublish": "npm publish --ignore-scripts --@github:registry='https://npm.pkg.github.com'"
   },

--- a/src/attachment.ts
+++ b/src/attachment.ts
@@ -1,6 +1,11 @@
 export default class Attachment {
   file: File
   directory: string | undefined
+  state: 'pending' | 'saving' | 'saved'
+  id: string | null | undefined
+  href: string | null | undefined
+  name: string | null | undefined
+  percent: number
 
   static traverse(transfer: DataTransfer, directory: boolean): Promise<Attachment[]> {
     return transferredFiles(transfer, directory)
@@ -23,6 +28,11 @@ export default class Attachment {
   constructor(file: File, directory?: string) {
     this.file = file
     this.directory = directory
+    this.state = 'pending'
+    this.id = null
+    this.href = null
+    this.name = null
+    this.percent = 0
   }
 
   get fullPath(): string {
@@ -31,6 +41,36 @@ export default class Attachment {
 
   isImage(): boolean {
     return ['image/gif', 'image/png', 'image/jpg', 'image/jpeg'].indexOf(this.file.type) > -1
+  }
+
+  saving(percent: number) {
+    if (this.state !== 'pending' && this.state !== 'saving') {
+      throw new Error(`Unexpected transition from ${this.state} to saving`)
+    }
+    this.state = 'saving'
+    this.percent = percent
+  }
+
+  saved(attributes: {id?: string | null; href?: string | null; name?: string | null}) {
+    if (this.state !== 'pending' && this.state !== 'saving') {
+      throw new Error(`Unexpected transition from ${this.state} to saved`)
+    }
+    this.state = 'saved'
+    this.id = attributes.id
+    this.href = attributes.href
+    this.name = attributes.name
+  }
+
+  isPending(): boolean {
+    return this.state === 'pending'
+  }
+
+  isSaving(): boolean {
+    return this.state === 'saving'
+  }
+
+  isSaved(): boolean {
+    return this.state === 'saved'
   }
 }
 

--- a/src/attachment.ts
+++ b/src/attachment.ts
@@ -2,9 +2,9 @@ export default class Attachment {
   file: File
   directory: string | undefined
   state: 'pending' | 'saving' | 'saved'
-  id: string | null | undefined
-  href: string | null | undefined
-  name: string | null | undefined
+  id: string | null
+  href: string | null
+  name: string | null
   percent: number
 
   static traverse(transfer: DataTransfer, directory: boolean): Promise<Attachment[]> {
@@ -56,9 +56,9 @@ export default class Attachment {
       throw new Error(`Unexpected transition from ${this.state} to saved`)
     }
     this.state = 'saved'
-    this.id = attributes?.id
-    this.href = attributes?.href
-    this.name = attributes?.name
+    this.id = attributes?.id ?? null
+    this.href = attributes?.href ?? null
+    this.name = attributes?.name ?? null
   }
 
   isPending(): boolean {

--- a/src/attachment.ts
+++ b/src/attachment.ts
@@ -51,14 +51,14 @@ export default class Attachment {
     this.percent = percent
   }
 
-  saved(attributes: {id?: string | null; href?: string | null; name?: string | null}) {
+  saved(attributes?: {id?: string | null; href?: string | null; name?: string | null}) {
     if (this.state !== 'pending' && this.state !== 'saving') {
       throw new Error(`Unexpected transition from ${this.state} to saved`)
     }
     this.state = 'saved'
-    this.id = attributes.id
-    this.href = attributes.href
-    this.name = attributes.name
+    this.id = attributes?.id
+    this.href = attributes?.href
+    this.name = attributes?.name
   }
 
   isPending(): boolean {

--- a/test/test.js
+++ b/test/test.js
@@ -1,3 +1,5 @@
+import {Attachment} from '../dist/index.js'
+
 describe('file-attachment', function() {
   describe('element creation', function() {
     it('creates from document.createElement', function() {
@@ -9,6 +11,49 @@ describe('file-attachment', function() {
     it('creates from constructor', function() {
       const el = new window.FileAttachmentElement()
       assert.equal('FILE-ATTACHMENT', el.nodeName)
+    })
+  })
+
+  describe('attachment', function() {
+    it('has a full path without a directory', function() {
+      const file = new File(['hubot'], 'test.txt', {type: 'text/plain'})
+      const attachment = new Attachment(file)
+      assert.equal('test.txt', attachment.fullPath)
+    })
+
+    it('has a full path with a directory', function() {
+      const file = new File(['hubot'], 'test.txt', {type: 'text/plain'})
+      const attachment = new Attachment(file, 'tmp')
+      assert.equal('tmp/test.txt', attachment.fullPath)
+    })
+
+    it('detects non image types', function() {
+      const file = new File(['hubot'], 'test.txt', {type: 'text/plain'})
+      const attachment = new Attachment(file)
+      assert(!attachment.isImage())
+    })
+
+    it('detects image types', function() {
+      const file = new File(['hubot'], 'test.gif', {type: 'image/gif'})
+      const attachment = new Attachment(file)
+      assert(attachment.isImage())
+    })
+
+    it('transitions through save states', function() {
+      const file = new File(['hubot'], 'test.txt', {type: 'text/plain'})
+      const attachment = new Attachment(file)
+      assert(attachment.isPending())
+      assert.equal(0, attachment.percent)
+
+      attachment.saving(10)
+      assert(attachment.isSaving())
+      assert.equal(10, attachment.percent)
+
+      attachment.saved({id: '42', name: 'saved.txt', href: '/s3/saved.txt'})
+      assert(attachment.isSaved())
+      assert.equal('42', attachment.id)
+      assert.equal('saved.txt', attachment.name)
+      assert.equal('/s3/saved.txt', attachment.href)
     })
   })
 })


### PR DESCRIPTION
Allow the host application to move attachments through a state machine while they are being saved. Attributes identifying the saved file may be added to the attachment when the upload is complete.