### PR TITLE
Add tests for event listeners and attach

### DIFF
--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,5 +1,8 @@
 {
   "parser": "espree",
+  "parserOptions": {
+    "ecmaVersion": 8
+  },
   "env": {
     "mocha": true
   },

--- a/test/test.js
+++ b/test/test.js
@@ -56,4 +56,59 @@ describe('file-attachment', function() {
       assert.equal('/s3/saved.txt', attachment.href)
     })
   })
+
+  describe('element', function() {
+    let fileAttachment
+    beforeEach(function() {
+      document.body.innerHTML = `<file-attachment></file-attachment>`
+
+      fileAttachment = document.querySelector('file-attachment')
+    })
+
+    afterEach(function() {
+      document.body.innerHTML = ''
+    })
+
+    it('attaches files via .attach', async function() {
+      const listener = once('file-attachment-accepted')
+
+      const dataTransfer = new DataTransfer()
+      const file = new File(['hubot'], 'test.txt', {type: 'text/plain'})
+      dataTransfer.items.add(file)
+      fileAttachment.attach(dataTransfer)
+
+      const event = await listener
+      assert.equal('test.txt', event.detail.attachments[0].file.name)
+    })
+
+    it('attaches files via drop', async function() {
+      const listener = once('file-attachment-accepted')
+
+      const dataTransfer = new DataTransfer()
+      const file = new File(['hubot'], 'test.txt', {type: 'text/plain'})
+      dataTransfer.items.add(file)
+      const dropEvent = new DragEvent('drop', {bubbles: true, dataTransfer})
+      fileAttachment.dispatchEvent(dropEvent)
+
+      const event = await listener
+      assert.equal('test.txt', event.detail.attachments[0].file.name)
+    })
+
+    it('attaches images via paste', async function() {
+      const listener = once('file-attachment-accepted')
+
+      const dataTransfer = new DataTransfer()
+      const file = new File(['hubot'], 'test.png', {type: 'image/png'})
+      dataTransfer.items.add(file)
+      const dropEvent = new ClipboardEvent('paste', {bubbles: true, clipboardData: dataTransfer})
+      fileAttachment.dispatchEvent(dropEvent)
+
+      const event = await listener
+      assert.equal('test.png', event.detail.attachments[0].file.name)
+    })
+  })
 })
+
+function once(eventName) {
+  return new Promise(resolve => document.addEventListener(eventName, resolve, {once: true}))
+}


### PR DESCRIPTION
This adds some tests for the element behavior around event listeners and the public API `.attach`.

<img width="560" alt="image" src="https://user-images.githubusercontent.com/1153134/73983382-53a15400-4904-11ea-9a14-732a1eb18f5e.png">
