### PR TITLE
Add support for file inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,15 @@ import '@github/file-attachment-element'
 ```
 
 ```html
-<file-attachment directory>
+<file-attachment directory input="upload">
+  <input id="upload" type="file" multiple>
 </file-attachment>
 ```
+
+### Optional attributes
+
+- `file-attachment[directory]` enables traversing directories.
+- `file-attachment[input]` points to the ID of a file input inside of `<file-attachment>`. Files selected from the `<input>` will be attached to `<file-attachment>`. Supplying an input is strongly recommended in order to ensure users can upload files without a mouse or knowing where to paste files.
 
 ### Styling drag state
 

--- a/src/file-attachment-element.ts
+++ b/src/file-attachment-element.ts
@@ -8,6 +8,7 @@ class FileAttachmentElement extends HTMLElement {
     this.addEventListener('dragleave', onDragleave)
     this.addEventListener('drop', onDrop)
     this.addEventListener('paste', onPaste)
+    this.addEventListener('change', onChange)
   }
 
   get directory(): boolean {
@@ -131,4 +132,17 @@ function onPaste(event: ClipboardEvent) {
   const files: File[] = [file]
   container.attach(files)
   event.preventDefault()
+}
+
+function onChange(event: Event) {
+  const container = event.currentTarget
+  if (!(container instanceof FileAttachmentElement)) return
+  const input = event.target
+  if (!(input instanceof HTMLInputElement)) return
+
+  const files = input.files
+  if (!files || files.length === 0) return
+
+  container.attach(files)
+  input.value = ''
 }

--- a/src/file-attachment-element.ts
+++ b/src/file-attachment-element.ts
@@ -139,6 +139,8 @@ function onChange(event: Event) {
   if (!(container instanceof FileAttachmentElement)) return
   const input = event.target
   if (!(input instanceof HTMLInputElement)) return
+  const id = container.getAttribute('input')
+  if (!id || input.id !== id) return
 
   const files = input.files
   if (!files || files.length === 0) return

--- a/test/test.js
+++ b/test/test.js
@@ -60,7 +60,10 @@ describe('file-attachment', function() {
   describe('element', function() {
     let fileAttachment, input
     beforeEach(function() {
-      document.body.innerHTML = `<file-attachment><input type="file"></file-attachment>`
+      document.body.innerHTML = `
+        <file-attachment input="upload">
+          <input type="file" id="upload">
+        </file-attachment>`
 
       fileAttachment = document.querySelector('file-attachment')
       input = document.querySelector('input')

--- a/test/test.js
+++ b/test/test.js
@@ -58,11 +58,12 @@ describe('file-attachment', function() {
   })
 
   describe('element', function() {
-    let fileAttachment
+    let fileAttachment, input
     beforeEach(function() {
-      document.body.innerHTML = `<file-attachment></file-attachment>`
+      document.body.innerHTML = `<file-attachment><input type="file"></file-attachment>`
 
       fileAttachment = document.querySelector('file-attachment')
+      input = document.querySelector('input')
     })
 
     afterEach(function() {
@@ -105,6 +106,20 @@ describe('file-attachment', function() {
 
       const event = await listener
       assert.equal('test.png', event.detail.attachments[0].file.name)
+    })
+
+    it('attaches files via input', async function() {
+      const listener = once('file-attachment-accepted')
+
+      const dataTransfer = new DataTransfer()
+      const file = new File(['hubot'], 'test.png', {type: 'image/png'})
+      dataTransfer.items.add(file)
+      input.files = dataTransfer.files
+      input.dispatchEvent(new Event('change', {bubbles: true}))
+
+      const event = await listener
+      assert.equal('test.png', event.detail.attachments[0].file.name)
+      assert.equal(0, input.files.length)
     })
   })
 })


### PR DESCRIPTION
Fixes #2.

This adds support for `<input type="file">`, associating to `<file-attachment>` via an `input` attribute.

```html
<file-attachment input="upload">
  <input type="file" id="upload" multiple>
</file-attachment>
```

I opted to name the attribute `input` instead of `for` to avoid confusion with `<label for>`. In the case of `<label for>`, `input` is implicitly associated through nesting, which isn't the true here.