### PR TITLE
Register custom element just once

### DIFF
--- a/src/file-attachment-element.ts
+++ b/src/file-attachment-element.ts
@@ -1,6 +1,6 @@
 import Attachment from './attachment'
 
-class FileAttachmentElement extends HTMLElement {
+export default class FileAttachmentElement extends HTMLElement {
   constructor() {
     super()
     this.addEventListener('dragenter', onDragenter)
@@ -46,13 +46,6 @@ class FileAttachmentElement extends HTMLElement {
       )
     }
   }
-}
-
-export default FileAttachmentElement
-
-if (!window.customElements.get('file-attachment')) {
-  window.FileAttachmentElement = FileAttachmentElement
-  window.customElements.define('file-attachment', FileAttachmentElement)
 }
 
 function hasFile(transfer: DataTransfer): boolean {


### PR DESCRIPTION
The file-attachment-element module is responsible for exporting the class while the index module [registers it](https://github.com/github/file-attachment-element/blob/66694e47d600f36f211bfaab5de810af3192bb05/src/index.ts#L12-L15) in the browser's custom element registry.