### PR TITLE
Default `transfer.files` to an empty array

### DIFF
--- a/src/attachment.ts
+++ b/src/attachment.ts
@@ -97,7 +97,7 @@ function transferredFiles(transfer: DataTransfer, directory: boolean): Promise<A
   if (directory && isDirectory(transfer)) {
     return traverse('', roots(transfer))
   }
-  return Promise.resolve(visible(Array.from(transfer.files)).map(f => new Attachment(f)))
+  return Promise.resolve(visible(Array.from(transfer.files || [])).map(f => new Attachment(f)))
 }
 
 function hidden(file: File | FileSystemEntry): boolean {


### PR DESCRIPTION
It seems that `DataTransfer.files` can be  `null` on some Firefox browsers even thought the spec says it should always be a list. I couldn't reproduce it locally so I'm not sure how users are triggering this.