### PR TITLE
Fix `types` reference in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Attach files via drag and drop or file input.",
   "main": "dist/index.umd.js",
   "module": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/file-attachment-element.d.ts",
   "license": "MIT",
   "repository": "github/file-attachment-element",
   "files": [


### PR DESCRIPTION
Missed this reference when I combined the files in #12. 