### PR TITLE
Bubble dragover and dragenter events

### DIFF
--- a/src/file-attachment-element.ts
+++ b/src/file-attachment-element.ts
@@ -73,6 +73,17 @@ function onDragenter(event: DragEvent) {
   if (dragging) {
     clearTimeout(dragging)
   }
+
+  const dragEvent = new CustomEvent('file-attachment-dragged', {
+    bubbles: true,
+    cancelable: true,
+    detail: {
+      dragEvent: event,
+      attachmentElement: target
+    }
+  })
+  target.dispatchEvent(dragEvent)
+
   dragging = window.setTimeout(() => target.removeAttribute('hover'), 200)
 
   const transfer = event.dataTransfer

--- a/src/file-attachment-element.ts
+++ b/src/file-attachment-element.ts
@@ -74,16 +74,6 @@ function onDragenter(event: DragEvent) {
     clearTimeout(dragging)
   }
 
-  const dragEvent = new CustomEvent('file-attachment-dragged', {
-    bubbles: true,
-    cancelable: true,
-    detail: {
-      dragEvent: event,
-      target
-    }
-  })
-  target.dispatchEvent(dragEvent)
-
   dragging = window.setTimeout(() => target.removeAttribute('hover'), 200)
 
   const transfer = event.dataTransfer
@@ -92,7 +82,6 @@ function onDragenter(event: DragEvent) {
   transfer.dropEffect = 'copy'
   target.setAttribute('hover', '')
 
-  event.stopPropagation()
   event.preventDefault()
 }
 

--- a/src/file-attachment-element.ts
+++ b/src/file-attachment-element.ts
@@ -79,7 +79,7 @@ function onDragenter(event: DragEvent) {
     cancelable: true,
     detail: {
       dragEvent: event,
-      attachmentElement: target
+      target
     }
   })
   target.dispatchEvent(dragEvent)

--- a/test/test.js
+++ b/test/test.js
@@ -131,7 +131,7 @@ describe('file-attachment', function () {
       input.dispatchEvent(dragEvent)
       const event = await listener
       assert.equal(dragEvent, event.detail.dragEvent)
-      assert.equal(fileAttachment, event.detail.attachmentElement)
+      assert.equal(fileAttachment, event.detail.target)
     })
 
     it('fires a file-attachment-dragged event on dragover', async function () {
@@ -140,7 +140,7 @@ describe('file-attachment', function () {
       input.dispatchEvent(dragEvent)
       const event = await listener
       assert.equal(dragEvent, event.detail.dragEvent)
-      assert.equal(fileAttachment, event.detail.attachmentElement)
+      assert.equal(fileAttachment, event.detail.target)
     })
   })
 })

--- a/test/test.js
+++ b/test/test.js
@@ -124,6 +124,24 @@ describe('file-attachment', function () {
       assert.equal('test.png', event.detail.attachments[0].file.name)
       assert.equal(0, input.files.length)
     })
+
+    it('fires a file-attachment-dragged event on dragenter', async function () {
+      const listener = once('file-attachment-dragged')
+      const dragEvent = new Event('dragenter', {bubbles: true})
+      input.dispatchEvent(dragEvent)
+      const event = await listener
+      assert.equal(dragEvent, event.detail.dragEvent)
+      assert.equal(fileAttachment, event.detail.attachmentElement)
+    })
+
+    it('fires a file-attachment-dragged event on dragover', async function () {
+      const listener = once('file-attachment-dragged')
+      const dragEvent = new Event('dragover', {bubbles: true})
+      input.dispatchEvent(dragEvent)
+      const event = await listener
+      assert.equal(dragEvent, event.detail.dragEvent)
+      assert.equal(fileAttachment, event.detail.attachmentElement)
+    })
   })
 })
 

--- a/test/test.js
+++ b/test/test.js
@@ -125,22 +125,34 @@ describe('file-attachment', function () {
       assert.equal(0, input.files.length)
     })
 
-    it('fires a file-attachment-dragged event on dragenter', async function () {
-      const listener = once('file-attachment-dragged')
-      const dragEvent = new Event('dragenter', {bubbles: true})
+    it('bubbles the dragenter event after cancelling its default behavior', async function () {
+      const dataTransfer = new DataTransfer()
+      const file = new File(['hubot'], 'test.txt', {type: 'text/plain'})
+      dataTransfer.items.add(file)
+
+      const dragEvent = new DragEvent('dragenter', {bubbles: true, cancelable: true, dataTransfer})
+
+      const listener = once('dragenter')
       input.dispatchEvent(dragEvent)
+
       const event = await listener
-      assert.equal(dragEvent, event.detail.dragEvent)
-      assert.equal(fileAttachment, event.detail.target)
+      assert.equal(dragEvent, event)
+      assert.equal(true, event.defaultPrevented)
     })
 
-    it('fires a file-attachment-dragged event on dragover', async function () {
-      const listener = once('file-attachment-dragged')
-      const dragEvent = new Event('dragover', {bubbles: true})
+    it('bubbles the dragover event after cancelling its default behavior', async function () {
+      const dataTransfer = new DataTransfer()
+      const file = new File(['hubot'], 'test.txt', {type: 'text/plain'})
+      dataTransfer.items.add(file)
+
+      const dragEvent = new DragEvent('dragover', {bubbles: true, cancelable: true, dataTransfer})
+
+      const listener = once('dragover')
       input.dispatchEvent(dragEvent)
+
       const event = await listener
-      assert.equal(dragEvent, event.detail.dragEvent)
-      assert.equal(fileAttachment, event.detail.target)
+      assert.equal(dragEvent, event)
+      assert.equal(true, event.defaultPrevented)
     })
   })
 })


### PR DESCRIPTION
## What this PR does

### Current direction
The implementation for https://github.com/github/github/pull/190219 needs
an event to kick off finding the cursor position, and after some discussion it makes the most sense to
bubble the `dragover` and `dragenter` events that we're currently stopping.  

### Originally
The implementation for https://github.com/github/github/pull/190219 needs
an event to kick off finding the cursor position, and rather than directly propagating the
DragEvent it seems prudent to fire a CustomEvent solely used by that consumer.
That'll avoid any unintended side effects in the document at large.





