### PR TITLE
Add isVideo check, similar to isImage

### DIFF
--- a/src/attachment.ts
+++ b/src/attachment.ts
@@ -43,6 +43,10 @@ export default class Attachment {
     return ['image/gif', 'image/png', 'image/jpg', 'image/jpeg'].indexOf(this.file.type) > -1
   }
 
+  isVideo(): boolean {
+    return ['video/mp4', 'video/quicktime'].indexOf(this.file.type) > -1
+  }
+
   saving(percent: number): void {
     if (this.state !== 'pending' && this.state !== 'saving') {
       throw new Error(`Unexpected transition from ${this.state} to saving`)

--- a/test/test.js
+++ b/test/test.js
@@ -39,6 +39,24 @@ describe('file-attachment', function () {
       assert(attachment.isImage())
     })
 
+    it('detects mp4 video types', function () {
+      const file = new File(['hubot'], 'test.mp4', {type: 'video/mp4'})
+      const attachment = new Attachment(file)
+      assert(attachment.isVideo())
+    })
+
+    it('detects quicktime video types', function () {
+      const file = new File(['hubot'], 'test.mov', {type: 'video/quicktime'})
+      const attachment = new Attachment(file)
+      assert(attachment.isVideo())
+    })
+
+    it('detects non video types', function () {
+      const file = new File(['hubot'], 'test.txt', {type: 'text/plain'})
+      const attachment = new Attachment(file)
+      assert(!attachment.isVideo())
+    })
+
     it('transitions through save states', function () {
       const file = new File(['hubot'], 'test.txt', {type: 'text/plain'})
       const attachment = new Attachment(file)


### PR DESCRIPTION
In https://github.com/github/github/pull/162936 we added an `isVideo` function to a downstream file, mentioning that we should eventually put it into `file-attachment-element`. 
https://github.com/github/github/blob/8c9b18cf24713d8be3888f31205ec43ff9f8e7a0/app/assets/modules/github/behaviors/commenting/markdown.ts#L38-L42

There's nothing depending on this change yet. I'm drafting some other changes and figured I'd take a shot at it while I was here.