### PR TITLE
Check if pastedFile is a file before run getAsFile

### DIFF
--- a/src/file-attachment-element.ts
+++ b/src/file-attachment-element.ts
@@ -116,7 +116,7 @@ const images = /^image\/(gif|png|jpeg)$/
 
 function pastedFile(items: DataTransferItemList): File | null {
   for (const item of items) {
-    if (images.test(item.type)) {
+    if (item.kind === 'file' && images.test(item.type)) {
       return item.getAsFile()
     }
   }

--- a/test/test.js
+++ b/test/test.js
@@ -172,6 +172,20 @@ describe('file-attachment', function () {
       assert.equal(dragEvent, event)
       assert.equal(true, event.defaultPrevented)
     })
+
+    it('attaches the correct file when browser sends multiple data transfer items with image as type', async function () {
+      const listener = once('file-attachment-accepted')
+
+      const dataTransfer = new DataTransfer()
+      const file = new File(['hubot'], 'test.png', {type: 'image/png'})
+      dataTransfer.items.add('some string', 'image/jpeg')
+      dataTransfer.items.add(file)
+      const dropEvent = new ClipboardEvent('paste', {bubbles: true, clipboardData: dataTransfer})
+      fileAttachment.dispatchEvent(dropEvent)
+
+      const event = await listener
+      assert.equal('test.png', event.detail.attachments[0].file.name)
+    })
   })
 })
 


### PR DESCRIPTION
Received from two friends (@michel-gatti and @fpgentil) that since ~ 2 weeks ago they can't Paste Print Screens direct on inputs that uses file-attachment-element.

Both are using linux. @michel-gatti is using Mint with chrome Version 93.0.4577.82 (Official Build) (64-bit) and @fpgentil is using Fedora 34 - Gnome 40.4.0 - Kernel 5.13.14-200.fc34.x86_64 with a clipboard manager tool called flameshot

Both says that they can paste the files from screenshot in other browser apps (like Google Docs) but not on fields that uses file-attachment-element.

@michel-gatti made some tests and looks like his clipboard manager / browser is sending all these DataTransferItem when pasting


![](https://user-images.githubusercontent.com/771411/134514359-87f01edd-7048-4a67-ae08-036dd62b0aa7.png)

This patch on the file-attachment-element gets only the datatransferitem that is really a FILE before run getAsFile

I've tested with him and after this patch it got work again